### PR TITLE
A different approach to chromium accepting my responses

### DIFF
--- a/component/rest_of_chromium.patch
+++ b/component/rest_of_chromium.patch
@@ -142,18 +142,20 @@ index febbb4791f6a2..7e4b1153213fe 100644
  #if BUILDFLAG(ENABLE_OFFLINE_PAGES)
    interceptors.push_back(
        std::make_unique<offline_pages::OfflinePageURLLoaderRequestInterceptor>(
-diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
-index d66761d9e1030..ffd9e852f86e9 100644
---- a/content/browser/renderer_host/navigation_request.cc
-+++ b/content/browser/renderer_host/navigation_request.cc
-@@ -872,7 +872,9 @@ GetOriginForURLLoaderFactoryUncheckedWithDebugInfo(
-             url::Origin::Create(navigation_request->GetWebBundleURL())),
-         "web_bundle");
-   }
--
-+  if (common_params.url.SchemeIs("ipfs") || common_params.url.SchemeIs("ipns")) {
-+    return std::make_pair(url::Origin::Create(common_params.url), "ca_uri");
+diff --git a/chrome/common/chrome_content_client.cc b/chrome/common/chrome_content_client.cc
+index db08f6151229e..e63c004ec6398 100644
+--- a/chrome/common/chrome_content_client.cc
++++ b/chrome/common/chrome_content_client.cc
+@@ -292,6 +292,12 @@ void ChromeContentClient::AddAdditionalSchemes(Schemes* schemes) {
+ #if BUILDFLAG(IS_ANDROID)
+   schemes->local_schemes.push_back(url::kContentScheme);
+ #endif
++  for ( const char* ip_s : {"ipfs", "ipns"} ) {
++    schemes->standard_schemes.push_back(ip_s);
++    schemes->cors_enabled_schemes.push_back(ip_s);
++    schemes->secure_schemes.push_back(ip_s);
++    schemes->csp_bypassing_schemes.push_back(ip_s);
 +  }
-   // In cases not covered above, URLLoaderFactory should be associated with the
-   // origin of |common_params.url| and/or |common_params.initiator_origin|.
-   return std::make_pair(
+ }
+ 
+ std::u16string ChromeContentClient::GetLocalizedString(int message_id) {


### PR DESCRIPTION
I wonder if adding something into AddAddtionalSchemes in //chrome might be more palatable than the change I was making in navigation_request.cc down in render_host.

:arrow_up: this is very much the question I want to ask.

It is worth noting, some of the other things in AddAdditionalSchemes are behind build flags, which was something raised as a possibility for this project. So, if we wanted to go that way, it's nice to know there's precedent.

The biggest downside is that this does mean CIDs are getting lowercased again, as they were with the http redirect. So the CIDv0 style (Qm...) are a non-starter as they're case-sensitive. And now that I'm going block-by-block (for ipfs:// anyhow), this is an even bigger problem as, at least for the moment, I'm resolving the binary CIDs in the PB-DAG links as CIDv0. So, if we go this route that's something that must be addressed.

But before I do that, I want to get a consensus on whether this is a worthwhile and good approach.
