### PR TITLE
Push library artifacts upon release

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -1,6 +1,8 @@
 name: Basic library (ipfs_client) build
 on:
   pull_request:
+  release:
+      types: [created]
 jobs:
   test:
     name: Run Tests & Publish Coverage Report
@@ -117,9 +119,11 @@ jobs:
       - name: Build
         shell: bash
         run: cmake --build build --config ${{ matrix.config.build_type }} --target package
-      - name: Upload
-        uses: actions/upload-artifact@v3
-        with:
-          name: static_library.${{ matrix.config.os }}
-          path: build/library/libipfs_client.a # TODO .lib naming on Windows
-          retention-days: 1
+      - name: Upload to release
+        if: github.event_name == 'release' && matrix.config.build_type == 'Release'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          cd build
+          python3 ../cmake/release.py --library-only

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -205,7 +205,7 @@ mark_as_advanced(
 
 get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG))
-    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+    message(STATUS "Code coverage results with an optimised (non-Debug) build may be misleading")
 endif() # NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")

--- a/cmake/chromium.py
+++ b/cmake/chromium.py
@@ -108,7 +108,7 @@ if isfile(join(build_dir,'fresh')):
 if not isfile(join(src,'.landmines')):
     run([python, join(depot_tools_dir,'gclient.py'), 'runhooks', '-j', jobs])
 
-with open(join(src,'chrome', 'browser', 'BUILD.gn')) as w:
+with open(join(src, 'chrome', 'browser', 'BUILD.gn')) as w:
     content = w.read()
     if 'components/ipfs' in content:
         verbose('Chromium seems to be already patched.')

--- a/cmake/patch.py
+++ b/cmake/patch.py
@@ -14,8 +14,10 @@ except ModuleNotFoundError:
 
 
 def osname():
-    if platform == 'linux': return 'Linux'
-    if platform == 'darwin': return 'Mac'
+    if platform == 'linux':
+        return 'Linux'
+    if platform == 'darwin':
+        return 'Mac'
     return 'Windows'
 
 
@@ -162,9 +164,10 @@ if __name__ == '__main__':
             print(m)
     elif argv[1] == 'releases':
         p = Patcher('/mnt/big/lbl/code/chromium/src', 'git', 'Debug')
-        for chan in ['Dev', 'Beta', 'Stable', 'Extended']:
-            rels = p.release_versions(chan)
-            for rel in rels:
-                print(chan, rel)
+        for os in ['Linux', 'Mac', 'Windows']:
+            for chan in ['Dev', 'Beta', 'Stable', 'Extended']:
+                rels = p.release_versions(chan, os)
+                for rel in rels:
+                    print(chan, os, rel)
     else:
         Patcher(*argv[1:]).create_patch_file()

--- a/cmake/version.py
+++ b/cmake/version.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 from os.path import dirname, join
+from sys import argv
+
 import subprocess
 
 here = join(dirname(__file__), '..')
@@ -28,8 +30,19 @@ def tag_to_version(tag):
         return 0
 
 
+git(['fetch', '--all', '--tags'])
+
+
+def dist(x):
+    return int(git(['rev-list', '--count', f'{x}..HEAD']))
+
+
+def recent():
+    tags = [(dist(x), x) for x in git(['tag']).splitlines() if tag_to_version(x) > 0]
+    return min(tags)[1]
+
+
 def on_tag():
-    git(['fetch', '--all', '--tags'])
     return git(['describe', '--tags', '--exact-match', 'HEAD'])
 
 
@@ -50,4 +63,7 @@ def deduce():
 
 
 if __name__ == "__main__":
-    print(deduce(), end='')
+    if len(argv) > 1 and argv[1] == 'recent':
+        print(recent(), end='')
+    else:
+        print(deduce(), end='')

--- a/component/cache_requestor.cc
+++ b/component/cache_requestor.cc
@@ -16,7 +16,7 @@ Self::CacheRequestor(net::CacheType typ,
                      base::FilePath base)
     : type_{typ}, state_{state} {
   if (!base.empty()) {
-    path_ = base.Append("IpfsBlockCache");
+    path_ = base.AppendASCII("IpfsBlockCache");
   }
   Start();
 }

--- a/component/ipns_url_loader.cc
+++ b/component/ipns_url_loader.cc
@@ -91,7 +91,7 @@ void ipfs::IpnsUrlLoader::Next() {
   auto resolved = state_.names().NameResolvedTo(host_);
   if (resolved.empty()) {
     if (!RequestIpnsRecord()) {
-      LOG(INFO) << "Treatin '" << host_ << "' as a DNSLink host.";
+      LOG(INFO) << "Treating '" << host_ << "' as a DNSLink host.";
       QueryDns(host_);
     }
   } else if (resolved == IpnsNames::kNoSuchName) {

--- a/doc/todo.md
+++ b/doc/todo.md
@@ -25,6 +25,7 @@
   - Etag
   - Resolve identity CIDs internally
   - Different headers for IPNS name resolution requests if they came from cache
+  - IPNS recursion limit
 * Dev QoL
   - Docker builds verifying every documented build approach
   - Github Action release including uploading library artifacts

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -80,7 +80,7 @@ install(
 )
 install(TARGETS ipfs_client)
 
-set(CPACK_GENERATOR TGZ)
+set(CPACK_GENERATOR TGZ;ZIP)
 find_program(DPKG_BUILDPACKAGE dpkg-buildpackage)
 if(DPKG_BUILDPACKAGE)
     list(APPEND CPACK_GENERATOR DEB)
@@ -101,6 +101,7 @@ endif()
 set(CPACK_PACKAGE_VERSION "${CMAKE_PROJECT_VERSION}")
 set(CPACK_PACKAGE_VENDOR "LBL")
 set(CPACK_PACKAGE_CONTACT "john@littlebearlabs.io")
+set(CPACK_ARCHIVE_FILE_NAME "ipfs-client")
 include(CPack)
 
 add_custom_target(upload_library


### PR DESCRIPTION
Inspired by recent events, hopefully this will work seamlessly next time we do a release - GitHub actions will build the library for Linux, Mac & Windows and upload the artifacts to the release. Would be neat.